### PR TITLE
Update sendrecv.py

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -388,7 +388,7 @@ def sendpfast(x, pps=None, mbps=None, realtime=None, loop=0, file_cache=False, i
     """Send packets at layer 2 using tcpreplay for performance
 
     :param pps:  packets per second
-    :param mpbs: MBits per second
+    :param mbps: MBits per second
     :param realtime: use packet's timestamp, bending time with real-time value
     :param loop: number of times to process the packet list
     :param file_cache: cache packets in RAM instead of reading from


### PR DESCRIPTION
Parameter in sendpfast should be named "mbps" not "mpbs" there is a typo in help and API documentation

This is just a checklist to guide you. You can remove it safely.

**Checklist:**

-   [ ] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

> brief description what this PR will do, e.g. fixes broken dissection of XXX

> if required - short explanation why you fixed something in a way that may look more complicated as it actually is

> if required - outline impacts on other parts of the library

fixes #xxx (add issue number here if appropriate, else remove this line)
